### PR TITLE
actions: Use the latest ubuntu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ env:
 
 jobs:
   docker_image_job:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       # don't need to use the actions/checkout when using setup-buildx-action
 


### PR DESCRIPTION
dependabot does not support github actions runner,
so use latest.
